### PR TITLE
do not recreate components if they already exist

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
+++ b/bepinex_dev/SPTQuestingBots/Components/LocationData.cs
@@ -46,25 +46,25 @@ namespace SPTQuestingBots.Components
 
             UpdateMaxTotalBots();
 
-            Singleton<GameWorld>.Instance.gameObject.AddComponent<BotLogic.HiveMind.BotHiveMindMonitor>();
+            Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<BotLogic.HiveMind.BotHiveMindMonitor>();
 
             if (ConfigController.Config.Questing.Enabled)
             {
                 QuestHelpers.ClearCache();
-                Singleton<GameWorld>.Instance.gameObject.AddComponent<BotQuestBuilder>();
-                Singleton<GameWorld>.Instance.gameObject.AddComponent<DebugData>();
+                Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<BotQuestBuilder>();
+                Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<DebugData>();
             }
 
             if (ConfigController.Config.BotSpawns.Enabled)
             {
                 if (ConfigController.Config.BotSpawns.PMCs.Enabled)
                 {
-                    Singleton<GameWorld>.Instance.gameObject.AddComponent<Spawning.PMCGenerator>();
+                    Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Spawning.PMCGenerator>();
                 }
 
                 if (ConfigController.Config.BotSpawns.PScavs.Enabled && !CurrentLocation.DisabledForScav)
                 {
-                    Singleton<GameWorld>.Instance.gameObject.AddComponent<Spawning.PScavGenerator>();
+                    Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Spawning.PScavGenerator>();
                 }
 
                 BotGenerator.RunBotGenerationTasks();
@@ -72,7 +72,7 @@ namespace SPTQuestingBots.Components
 
             if (ConfigController.Config.Debug.Enabled)
             {
-                Singleton<GameWorld>.Instance.gameObject.AddComponent<PathRender>();
+                Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<PathRender>();
             }
         }
 

--- a/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
@@ -27,7 +27,7 @@ namespace SPTQuestingBots.Patches
                 UnityEngine.GameObject.Destroy(oldLocationData);
             }
 
-            Singleton<GameWorld>.Instance.gameObject.AddComponent<Components.LocationData>();
+            Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Components.LocationData>();
 
             if (ConfigController.Config.BotSpawns.DelayGameStartUntilBotGenFinishes)
             {


### PR DESCRIPTION
QB's `LocationData` component is created when `BotsController.AddActivePLayer` is called.
In SIT, we need to call that function several times for obvious reasons, which calls the `BotHiveMindMonitor` constructor multiple times, which tries to add the same key to the static `BotHiveMindMonitor.sensors` multiple times.
This patch makes it so we do not create `LocationData` and other components again if they already exist.

Stacktrace of the error:
```
EXCEPTION: System.ArgumentException: An item with the same key has already been added. Key: InCombat
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x000c1] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00000] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at SPTQuestingBots.BotLogic.HiveMind.BotHiveMindMonitor..ctor () [0x00019] in <fbf3b433c40a4cb485ef1d651ee9eb6b>:0 
2024-04-26 23:38:39.098 +02:00|0.14.1.3.29351|Error|Default|ArgumentException: An item with the same key has already been added. Key: InCombat
System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
SPTQuestingBots.BotLogic.HiveMind.BotHiveMindMonitor..ctor () (at <fbf3b433c40a4cb485ef1d651ee9eb6b>:0)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
LogHandler:UnityEngine.ILogHandler.LogException(Exception, Object)
UnityEngine.GameObject:AddComponent()
SPTQuestingBots.Components.LocationData:Awake()
UnityEngine.GameObject:AddComponent()
SPTQuestingBots.Patches.AddActivePlayerPatch:PatchPostfix()
EFT.BotsController:DMD<EFT.BotsController::AddActivePLayer>(BotsController, Player)
StayInTarkov.Coop.Components.CoopGameComponents.<EverySecondCoroutine>d__98:MoveNext()
UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)
```