### PR TITLE
[fix] do not destroy locationdata since we do not recreate it

### DIFF
--- a/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
+++ b/bepinex_dev/SPTQuestingBots/Patches/AddActivePlayerPatch.cs
@@ -21,12 +21,6 @@ namespace SPTQuestingBots.Patches
         [PatchPostfix]
         private static void PatchPostfix()
         {
-            if (Singleton<GameWorld>.Instance.gameObject.TryGetComponent(out Components.LocationData oldLocationData))
-            {
-                LoggingController.LogInfo("Destroying previous location data...");
-                UnityEngine.GameObject.Destroy(oldLocationData);
-            }
-
             Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<Components.LocationData>();
 
             if (ConfigController.Config.BotSpawns.DelayGameStartUntilBotGenFinishes)


### PR DESCRIPTION
#2 had a bug because [`Object.Destroy`](https://docs.unity3d.com/ScriptReference/Object.Destroy.html) destroys the object at the end of the current frame, but the check for `GetOrAddComponent` is done before that. New component would not be created, old component would get destroyed at the end of the frame.

We do not destroy the `LocationData` component anymore since there's no reason to. Alternative would be to call `Object.DestroyImmediate` to destroy right now as opposed to end of frame.

Tested with 2 players on Customs then Factory